### PR TITLE
better invariant checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 .claude/
 CLAUDE.md
 .tmp/
+.jqwik-database
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <release>21</release>
-                    <failOnWarning>false</failOnWarning>
+                    <failOnWarning>true</failOnWarning>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-serial</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <jdk.version>21</jdk.version>
         <junit.version>4.13.1</junit.version>
         <lombok.version>1.18.42</lombok.version>
+        <jqwik.version>1.9.2</jqwik.version>
     </properties>
 
     <dependencies>
@@ -63,6 +64,30 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- JUnit Vintage Engine for running JUnit 4 tests with JUnit Platform -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit Jupiter Engine for running JUnit 5 tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- jqwik for property-based testing -->
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>${jqwik.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <distributionManagement>
@@ -80,15 +105,62 @@
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <release>21</release>
-                    <failOnWarning>true</failOnWarning> <!-- treat warnings as errors -->
+                    <failOnWarning>false</failOnWarning>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-serial</arg>
+                        <arg>-Xlint:-processing</arg>
+                        <arg>-Xlint:-try</arg>
+                        <arg>-Xdoclint:none</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${lombok.version}</version>
                         </path>
+                        <path>
+                            <groupId>org.jetbrains</groupId>
+                            <artifactId>annotations</artifactId>
+                            <version>26.0.2</version>
+                        </path>
                     </annotationProcessorPaths>
+                    <proc>full</proc>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*ITCase.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*ITCase.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStore.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStore.java
@@ -1627,7 +1627,8 @@ public class FileRecordStore implements AutoCloseable {
         if (payloadLength <= availableSpace) {
           long alignedPosition = alignToBlockSize(dataStartPtr);
           if (alignedPosition + payloadLength <= fileLength) {
-            RecordHeader allocatedRecord = new RecordHeader(alignedPosition, payloadLength, payloadLength);
+            // Provide default values for indexPosition and crc32
+            RecordHeader allocatedRecord = new RecordHeader(alignedPosition, payloadLength, payloadLength, -1, 0);
             logger.log(
                 Level.FINEST,
                 () ->

--- a/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
@@ -98,7 +98,7 @@ public class FileRecordStoreBuilder {
   private boolean allowZeroPreallocation = false;
   private boolean defensiveCopy = true;
   private int hintInitialKeyCount = 0; // 0 means use default calculation
-  private int hintPreferredBlockSize = 4 * 1024 * 1024; // 4 MiB default (SSD erasure block)
+  private int hintPreferredBlockSize = 4 * 1024 * 1024; // 4 MiB default (general alignment size; SSD erasure blocks typically range from 256 KiB to 4 MiB depending on the drive)
   private int hintPreferredExpandSize = 2 * 1024 * 1024; // 2 MiB default
 
   /// Extra capacity percent for expansion (0.0 to 1.0), default 0.2 for 20% growth.

--- a/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
@@ -98,7 +98,10 @@ public class FileRecordStoreBuilder {
   private boolean allowZeroPreallocation = false;
   private boolean defensiveCopy = true;
   private int hintInitialKeyCount = 0; // 0 means use default calculation
-  private int hintPreferredBlockSize = 4 * 1024 * 1024; // 4 MiB default (general alignment size; SSD erasure blocks typically range from 256 KiB to 4 MiB depending on the drive)
+  private int hintPreferredBlockSize =
+      4 * 1024
+          * 1024; // 4 MiB default (general alignment size; SSD erasure blocks typically range from
+  // 256 KiB to 4 MiB depending on the drive)
   private int hintPreferredExpandSize = 2 * 1024 * 1024; // 2 MiB default
 
   /// Extra capacity percent for expansion (0.0 to 1.0), default 0.2 for 20% growth.
@@ -457,10 +460,12 @@ public class FileRecordStoreBuilder {
           // Only delete if opening in READ_WRITE mode; otherwise fail fast
           if (accessMode == AccessMode.READ_ONLY) {
             throw new IllegalArgumentException(
-                "File exists at " + path + " but is not a valid FileRecordStore. "
+                "File exists at "
+                    + path
+                    + " but is not a valid FileRecordStore. "
                     + "Cannot open in READ_ONLY mode.");
           }
-          
+
           // Delete invalid file and create new store (overwrite behavior)
           logger.log(
               Level.WARNING,
@@ -505,11 +510,14 @@ public class FileRecordStoreBuilder {
           throw new IOException(
               "Failed to validate existing file at " + path + " in READ_ONLY mode", e);
         }
-        
+
         // Delete corrupted file and create new store
         logger.log(
             Level.WARNING,
-            "Failed to validate store file at " + path + ": " + e.getMessage() 
+            "Failed to validate store file at "
+                + path
+                + ": "
+                + e.getMessage()
                 + ". Deleting and creating new store");
         try {
           Files.deleteIfExists(path);

--- a/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/FileRecordStoreBuilder.java
@@ -50,9 +50,10 @@ public class FileRecordStoreBuilder {
   private com.github.simbo1905.nfp.srs.KeyType keyType =
       com.github.simbo1905.nfp.srs.KeyType.BYTE_ARRAY;
 
-  /// Magic number identifying valid FileRecordStore files (0xBEEBBEEB).
+  /// Magic number identifying valid FileRecordStore files (0xBEEBBEEBBEEBBEEB).
   /// Placed at the start of every file to detect corruption and incompatible formats.
-  static final int MAGIC_NUMBER = 0xBEEBBEEB;
+  /// Written as long (8 bytes) for 64-byte aligned file header.
+  static final long MAGIC_NUMBER = 0xBEEBBEEBBEEBBEEBL;
   /// Default maximum key length in bytes. Optimized for SSD performance and modern hash sizes.
   public static final int DEFAULT_MAX_KEY_LENGTH = 128;
   /// Theoretical maximum key length based on file format constraints
@@ -66,14 +67,17 @@ public class FileRecordStoreBuilder {
   /// File index to the magic number header.
   static final long MAGIC_NUMBER_HEADER_LOCATION = 0;
   /// File index to the key length header (after magic number).
-  static final long KEY_LENGTH_HEADER_LOCATION = Integer.BYTES;
+  /// Key length is written as long but read back as short for alignment.
+  static final long KEY_LENGTH_HEADER_LOCATION = Long.BYTES;
   /// File index to the num records header.
-  static final long NUM_RECORDS_HEADER_LOCATION = Integer.BYTES + Short.BYTES;
+  /// Record count is written as long but read back as int for alignment.
+  static final long NUM_RECORDS_HEADER_LOCATION = Long.BYTES + Long.BYTES;
   /// File index to the start of the data region beyond the index region
-  static final long DATA_START_HEADER_LOCATION = Integer.BYTES + Short.BYTES + Integer.BYTES;
-  /// Total length in bytes of the global database headers.
-  static final int FILE_HEADERS_REGION_LENGTH =
-      Integer.BYTES + Short.BYTES + Integer.BYTES + Long.BYTES;
+  static final long DATA_START_HEADER_LOCATION = Long.BYTES + Long.BYTES + Long.BYTES;
+  /// Total length in bytes of the global database headers (before padding).
+  /// Magic (8) + KeyLength (8) + RecordCount (8) + DataStartPtr (8) = 32 bytes.
+  /// Padded to 64 bytes minimum with 32 bytes reserved for future metadata.
+  static final int FILE_HEADERS_REGION_LENGTH = 64;
 
   // Default sizing constants
   // 1 MiB
@@ -94,8 +98,16 @@ public class FileRecordStoreBuilder {
   private boolean allowZeroPreallocation = false;
   private boolean defensiveCopy = true;
   private int hintInitialKeyCount = 0; // 0 means use default calculation
-  private int hintPreferredBlockSize = 4; // 4 KiB default
-  private int hintPreferredExpandSize = 1; // 1 MiB default
+  private int hintPreferredBlockSize = 4 * 1024 * 1024; // 4 MiB default (SSD erasure block)
+  private int hintPreferredExpandSize = 2 * 1024 * 1024; // 2 MiB default
+
+  /// Extra capacity percent for expansion (0.0 to 1.0), default 0.2 for 20% growth.
+  /// This is converted to expansionMultiplier (1.0 + expansionExtraPercent) in the store.
+  private double expansionExtraPercent = 0.2;
+
+  /// Hint for average record size in bytes (default 2 KiB).
+  /// Used to estimate initial header region size based on preferredBlockSize.
+  private int averageRecordSizeHintBytes = 2048;
 
   /// Sets the path for the database file.
   ///
@@ -244,7 +256,7 @@ public class FileRecordStoreBuilder {
       throw new IllegalArgumentException(
           "hintPreferredBlockSize must be positive and power of 2, got " + blockSizeKiB);
     }
-    this.hintPreferredBlockSize = blockSizeKiB;
+    this.hintPreferredBlockSize = blockSizeKiB * 1024;
     return this;
   }
 
@@ -258,7 +270,36 @@ public class FileRecordStoreBuilder {
       throw new IllegalArgumentException(
           "hintPreferredExpandSize must be positive, got " + expandSizeMiB);
     }
-    this.hintPreferredExpandSize = expandSizeMiB;
+    this.hintPreferredExpandSize = expandSizeMiB * 1024 * 1024;
+    return this;
+  }
+
+  /// Sets the expansion extra percent for header and data region growth.
+  /// Must be between 0.0 (exclusive) and 1.0 (exclusive).
+  /// Default is 0.2 (20% growth, i.e., 1.2x multiplier).
+  ///
+  /// @param percent the expansion percentage (0.0 < percent < 1.0)
+  /// @return this builder for chaining
+  public FileRecordStoreBuilder withExpansionExtraPercent(double percent) {
+    if (percent <= 0.0 || percent >= 1.0) {
+      throw new IllegalArgumentException(
+          "expansionExtraPercent must be between 0.0 and 1.0 (exclusive), got " + percent);
+    }
+    this.expansionExtraPercent = percent;
+    return this;
+  }
+
+  /// Sets the average record size hint in bytes.
+  /// Used to estimate initial header region size.
+  /// Default is 2048 bytes (2 KiB).
+  ///
+  /// @param bytes the average record size in bytes
+  /// @return this builder for chaining
+  public FileRecordStoreBuilder withAverageRecordSizeHint(int bytes) {
+    if (bytes <= 0) {
+      throw new IllegalArgumentException("averageRecordSizeHint must be positive, got " + bytes);
+    }
+    this.averageRecordSizeHintBytes = bytes;
     return this;
   }
 
@@ -275,11 +316,11 @@ public class FileRecordStoreBuilder {
     alignedKeyLength = Math.min(alignedKeyLength, maxKeyLength + Short.BYTES + Integer.BYTES);
     final var finalAlignedKeyLength = alignedKeyLength;
 
-    // Convert user-friendly units to bytes
-    int expansionSize = hintPreferredExpandSize * 1024 * 1024; // MiB to bytes
-    int blockSize = hintPreferredBlockSize * 1024; // KiB to bytes
+    // Use already-converted values (now in bytes)
+    int expansionSize = hintPreferredExpandSize;
+    int blockSize = hintPreferredBlockSize;
 
-    // Calculate initial header region size based on key count hint
+    // Calculate initial header region size based on key count hint or average record size
     int initialHeaderSize;
     if (hintInitialKeyCount > 0) {
       // User provided hint: calculate based on key count
@@ -288,16 +329,23 @@ public class FileRecordStoreBuilder {
       initialHeaderSize =
           Math.max(hintInitialKeyCount * indexEntryLength, DEFAULT_INITIAL_HEADER_SIZE);
     } else {
-      // Use default
-      initialHeaderSize = DEFAULT_INITIAL_HEADER_SIZE;
+      // Estimate based on average record size and preferredBlockSize
+      int estimatedRecordCount = blockSize / averageRecordSizeHintBytes;
+      int indexEntryLength = alignedKeyLength + Short.BYTES + Integer.BYTES + 20;
+      int headerBytes = estimatedRecordCount * indexEntryLength + FILE_HEADERS_REGION_LENGTH;
+      // Round up to nearest 4 KiB block
+      initialHeaderSize = ((headerBytes + 4095) / 4096) * 4096;
+      initialHeaderSize = Math.max(initialHeaderSize, DEFAULT_INITIAL_HEADER_SIZE);
     }
+
+    final var finalInitialHeaderSize = initialHeaderSize;
 
     logger.log(
         Level.FINE,
         () ->
             String.format(
                 "Resolved sizing: alignedKeyLength=%d, expansionSize=%d, blockSize=%d, initialHeaderSize=%d",
-                finalAlignedKeyLength, expansionSize, blockSize, initialHeaderSize));
+                finalAlignedKeyLength, expansionSize, blockSize, finalInitialHeaderSize));
 
     return new Config(expansionSize, blockSize, initialHeaderSize);
   }
@@ -364,7 +412,8 @@ public class FileRecordStoreBuilder {
           defensiveCopy,
           config.expansionSize,
           config.blockSize,
-          config.initialHeaderSize);
+          config.initialHeaderSize,
+          expansionExtraPercent);
     }
 
     if (path == null) {
@@ -401,10 +450,27 @@ public class FileRecordStoreBuilder {
               defensiveCopy,
               config.expansionSize,
               config.blockSize,
-              config.initialHeaderSize);
+              config.initialHeaderSize,
+              expansionExtraPercent);
         } else {
-          // File exists but isn't a valid store - create new store (overwrite)
-          // This preserves backward compatibility with tests that expect overwrite behavior
+          // File exists but isn't a valid store
+          // Only delete if opening in READ_WRITE mode; otherwise fail fast
+          if (accessMode == AccessMode.READ_ONLY) {
+            throw new IllegalArgumentException(
+                "File exists at " + path + " but is not a valid FileRecordStore. "
+                    + "Cannot open in READ_ONLY mode.");
+          }
+          
+          // Delete invalid file and create new store (overwrite behavior)
+          logger.log(
+              Level.WARNING,
+              "Deleting invalid store file at " + path + " before creating new store");
+          try {
+            Files.deleteIfExists(path);
+          } catch (SecurityException se) {
+            throw new IOException(
+                "Permission denied when attempting to delete invalid file: " + path, se);
+          }
 
           // Safety check: refuse read-write stores with zero pre-allocation unless explicitly opted
           // in
@@ -430,10 +496,27 @@ public class FileRecordStoreBuilder {
               defensiveCopy,
               config.expansionSize,
               config.blockSize,
-              config.initialHeaderSize);
+              config.initialHeaderSize,
+              expansionExtraPercent);
         }
       } catch (IOException e) {
-        // Can't read file - create new store (overwrite existing)
+        // Can't read file - only delete if opening in READ_WRITE mode
+        if (accessMode == AccessMode.READ_ONLY) {
+          throw new IOException(
+              "Failed to validate existing file at " + path + " in READ_ONLY mode", e);
+        }
+        
+        // Delete corrupted file and create new store
+        logger.log(
+            Level.WARNING,
+            "Failed to validate store file at " + path + ": " + e.getMessage() 
+                + ". Deleting and creating new store");
+        try {
+          Files.deleteIfExists(path);
+        } catch (SecurityException se) {
+          throw new IOException(
+              "Permission denied when attempting to delete corrupted file: " + path, se);
+        }
 
         // Safety check: refuse read-write stores with zero pre-allocation unless explicitly opted
         // in
@@ -459,7 +542,8 @@ public class FileRecordStoreBuilder {
             defensiveCopy,
             config.expansionSize,
             config.blockSize,
-            config.initialHeaderSize);
+            config.initialHeaderSize,
+            expansionExtraPercent);
       }
     } else {
       // File doesn't exist - create new
@@ -496,7 +580,8 @@ public class FileRecordStoreBuilder {
           defensiveCopy,
           config.expansionSize,
           config.blockSize,
-          config.initialHeaderSize);
+          config.initialHeaderSize,
+          expansionExtraPercent);
     }
   }
 
@@ -510,13 +595,13 @@ public class FileRecordStoreBuilder {
   /// @throws IOException if the file cannot be read
   private boolean isValidFileRecordStore(Path path, int expectedMaxKeyLength) throws IOException {
     try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(path.toFile(), "r")) {
-      // Empty files are never valid stores
+      // Empty files are valid - they will be initialized as new stores
       if (raf.length() == 0) {
-        logger.log(Level.FINE, "Validation failed: file is empty");
-        return false;
+        logger.log(Level.FINE, "Empty file detected - will initialize as new store");
+        return true;
       }
 
-      // Check if file has minimum required size for headers
+      // Check if file has minimum required size for headers (64 bytes)
       if (raf.length() < FILE_HEADERS_REGION_LENGTH) {
         logger.log(
             Level.FINE,
@@ -528,11 +613,11 @@ public class FileRecordStoreBuilder {
         return false;
       }
 
-      // First check the magic number to determine file format
+      // Read magic number (long, 8 bytes)
       raf.seek(0);
-      int magicNumber;
+      long magicNumber;
       try {
-        magicNumber = raf.readInt();
+        magicNumber = raf.readLong();
       } catch (java.io.EOFException e) {
         logger.log(Level.FINE, "Validation failed: EOF reading magic number");
         return false;
@@ -542,19 +627,23 @@ public class FileRecordStoreBuilder {
       int numRecords;
 
       if (magicNumber == MAGIC_NUMBER) {
-        // New format with magic number
+        // Valid format with magic number
         try {
           raf.seek(KEY_LENGTH_HEADER_LOCATION);
-          keyLength = raf.readShort() & 0xFFFF;
+          long keyLengthLong = raf.readLong();
+          keyLength = (int) keyLengthLong;
           raf.seek(NUM_RECORDS_HEADER_LOCATION);
-          numRecords = raf.readInt();
+          long numRecordsLong = raf.readLong();
+          numRecords = (int) numRecordsLong;
         } catch (java.io.EOFException e) {
           logger.log(Level.FINE, "Validation failed: EOF reading new format headers");
           return false;
         }
       } else {
-        // Old format without magic number - reject it
-        logger.log(Level.FINE, "Validation failed: old format file without magic number");
+        // Invalid magic number - reject
+        logger.log(
+            Level.FINE,
+            "Validation failed: invalid magic number 0x" + Long.toHexString(magicNumber));
         return false;
       }
 

--- a/src/main/java/com/github/simbo1905/nfp/srs/GuardedReentrantReadWriteLock.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/GuardedReentrantReadWriteLock.java
@@ -1,0 +1,70 @@
+package com.github.simbo1905.nfp.srs;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/// A guarded wrapper around ReentrantReadWriteLock that returns AutoCloseable guards,
+/// making it impossible to forget to unlock. Encapsulates the lock implementation
+/// to prevent direct access and potential misuse.
+public final class GuardedReentrantReadWriteLock {
+  private final ReentrantReadWriteLock lock;
+
+  public GuardedReentrantReadWriteLock(boolean fair) {
+    this.lock = new ReentrantReadWriteLock(fair);
+  }
+
+  public GuardedReentrantReadWriteLock() {
+    this(false);
+  }
+
+  /// Returns an AutoCloseable read lock guard. Usage:
+  /// <pre>
+  /// try (var ignored = guardedLock.readLock()) {
+  ///   // read operations here
+  /// }
+  /// </pre>
+  public ReadLockGuard readLock() {
+    return new ReadLockGuard(lock.readLock());
+  }
+
+  /// Returns an AutoCloseable write lock guard. Usage:
+  /// <pre>
+  /// try (var ignored = guardedLock.writeLock()) {
+  ///   // write operations here
+  /// }
+  /// </pre>
+  public WriteLockGuard writeLock() {
+    return new WriteLockGuard(lock.writeLock());
+  }
+
+  /// A read lock guard that automatically releases the lock when closed.
+  public static final class ReadLockGuard implements AutoCloseable {
+    private final Lock lock;
+
+    ReadLockGuard(Lock lock) {
+      this.lock = lock;
+      lock.lock();
+    }
+
+    @Override
+    public void close() {
+      lock.unlock();
+    }
+  }
+
+  /// A write lock guard that automatically releases the lock when closed.
+  public static final class WriteLockGuard implements AutoCloseable {
+    private final Lock lock;
+
+    WriteLockGuard(Lock lock) {
+      this.lock = lock;
+      lock.lock();
+    }
+
+    @Override
+    public void close() {
+      lock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/github/simbo1905/nfp/srs/GuardedReentrantReadWriteLock.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/GuardedReentrantReadWriteLock.java
@@ -1,7 +1,6 @@
 package com.github.simbo1905.nfp.srs;
 
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /// A guarded wrapper around ReentrantReadWriteLock that returns AutoCloseable guards,

--- a/src/main/java/com/github/simbo1905/nfp/srs/RecordHeader.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/RecordHeader.java
@@ -7,15 +7,10 @@ import java.util.Objects;
 /// Immutable record header representing a record's metadata in the file store.
 /// Uses static factory methods for atomic updates instead of Lombok @With.
 record RecordHeader(
-    /// File pointer to the first byte of record data (8 bytes).
     long dataPointer,
-    /// Actual number of bytes of data held in this record (4 bytes).
     int dataLength,
-    /// Number of bytes of data that this record can hold (4 bytes).
     int dataCapacity,
-    /// This header's position in the file index.
     int indexPosition,
-    /// CRC32 checksum of the header data (dataPointer + dataCapacity + dataLength).
     long crc32) {
 
   /// The fixed-size metadata envelope that describes a record header.
@@ -60,10 +55,8 @@ record RecordHeader(
 
   /// Computes CRC32 for header data (dataLength + dataCapacity + keyLength placeholder).
   /// Does NOT include file position (dataPointer) as that causes unnecessary churn when records
-  // move.
-  /// File position is transient metadata - including it would require recomputing CRCs on every
-  // move.
-  /// Includes keyLength placeholder for consistent envelope structure with key CRC.
+  /// move. File position is transient metadata - including it would require recomputing CRCs on every
+  /// move. Includes keyLength placeholder for consistent envelope structure with key CRC.
   private static long computeHeaderCrc(int dataLength, int dataCapacity) {
     // CRC covers the actual header data fields, not file position
     final int HEADER_DATA_SIZE =

--- a/src/main/java/com/github/simbo1905/nfp/srs/RecordHeader.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/RecordHeader.java
@@ -7,11 +7,7 @@ import java.util.Objects;
 /// Immutable record header representing a record's metadata in the file store.
 /// Uses static factory methods for atomic updates instead of Lombok @With.
 record RecordHeader(
-    long dataPointer,
-    int dataLength,
-    int dataCapacity,
-    int indexPosition,
-    long crc32) {
+    long dataPointer, int dataLength, int dataCapacity, int indexPosition, long crc32) {
 
   /// The fixed-size metadata envelope that describes a record header.
   /// This envelope includes *all* fixed-width metadata fields for the record:
@@ -55,7 +51,8 @@ record RecordHeader(
 
   /// Computes CRC32 for header data (dataLength + dataCapacity + keyLength placeholder).
   /// Does NOT include file position (dataPointer) as that causes unnecessary churn when records
-  /// move. File position is transient metadata - including it would require recomputing CRCs on every
+  /// move. File position is transient metadata - including it would require recomputing CRCs on
+  // every
   /// move. Includes keyLength placeholder for consistent envelope structure with key CRC.
   private static long computeHeaderCrc(int dataLength, int dataCapacity) {
     // CRC covers the actual header data fields, not file position

--- a/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
@@ -40,7 +40,7 @@ public class UUIDGenerator {
   /// Generates a time-based UUID with sub-millisecond ordering within a single JVM.
   ///
   /// There is no guarantee that the time+counter of the most significant long will be unique across JVMs.
-  /// In the lower 64 bits we use a random long. This makes it improbably to get any collisions across JVMs.
+  /// In the lower 64 bits we use a random long. This makes it highly improbable to get any collisions across JVMs.
   /// Within a given JVM we will have good time based ordering.
   ///
   /// @return A new UUID with time-based ordering and global uniqueness.

--- a/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
@@ -29,7 +29,8 @@ public class UUIDGenerator {
   private static final AtomicLong sequence = new AtomicLong();
 
   /// This takes the Unix/Java epoch time in milliseconds, bit shifts it left by 20 bits, and then
-  /// masks in the least significant 20 bits of the local counter. That gives us a million unique values per millisecond.
+  /// masks in the least significant 20 bits of the local counter. That gives us a million unique
+  // values per millisecond.
   static long epochTimeThenCounterMsb() {
     long currentMillis = System.currentTimeMillis();
     // Take the least significant 20 bits from our atomic sequence
@@ -39,8 +40,10 @@ public class UUIDGenerator {
 
   /// Generates a time-based UUID with sub-millisecond ordering within a single JVM.
   ///
-  /// There is no guarantee that the time+counter of the most significant long will be unique across JVMs.
-  /// In the lower 64 bits we use a random long. This makes it highly improbable to get any collisions across JVMs.
+  /// There is no guarantee that the time+counter of the most significant long will be unique across
+  // JVMs.
+  /// In the lower 64 bits we use a random long. This makes it highly improbable to get any
+  // collisions across JVMs.
   /// Within a given JVM we will have good time based ordering.
   ///
   /// @return A new UUID with time-based ordering and global uniqueness.

--- a/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
+++ b/src/main/java/com/github/simbo1905/nfp/srs/UUIDGenerator.java
@@ -29,9 +29,7 @@ public class UUIDGenerator {
   private static final AtomicLong sequence = new AtomicLong();
 
   /// This takes the Unix/Java epoch time in milliseconds, bit shifts it left by 20 bits, and then
-  // masks in the least
-  /// significant 20 bits of the local counter. That gives us a million unique values per
-  // millisecond.
+  /// masks in the least significant 20 bits of the local counter. That gives us a million unique values per millisecond.
   static long epochTimeThenCounterMsb() {
     long currentMillis = System.currentTimeMillis();
     // Take the least significant 20 bits from our atomic sequence
@@ -41,10 +39,8 @@ public class UUIDGenerator {
 
   /// Generates a time-based UUID with sub-millisecond ordering within a single JVM.
   ///
-  /// There is no guarantee that the time+counter of the most significant long will be unique across
-  // JVMs.
-  /// In the lower 64 bits we use a random long. This makes it improbably to get any collisions
-  // across JVMs.
+  /// There is no guarantee that the time+counter of the most significant long will be unique across JVMs.
+  /// In the lower 64 bits we use a random long. This makes it improbably to get any collisions across JVMs.
   /// Within a given JVM we will have good time based ordering.
   ///
   /// @return A new UUID with time-based ordering and global uniqueness.

--- a/src/test/java/com/github/simbo1905/nfp/srs/FileRecordStoreConstructorResourceLeakDemoTest.java
+++ b/src/test/java/com/github/simbo1905/nfp/srs/FileRecordStoreConstructorResourceLeakDemoTest.java
@@ -26,7 +26,7 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
 
       // Corrupt the key length header to trigger validation failure
       try (RandomAccessFile raf = new RandomAccessFile(tempFile.toFile(), "rw")) {
-        raf.seek(4); // Key length position in new format (after magic number)
+        raf.seek(8); // Key length location = Long.BYTES (8 bytes after magic number)
         raf.writeByte(32); // Change key length from 64 to 32
       }
 
@@ -50,7 +50,8 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
                     true, // defensiveCopy
                     1024 * 1024, // preferredExpansionSize
                     4 * 1024, // preferredBlockSize
-                    64 * 1024)) { // initialHeaderRegionSize
+                    64 * 1024, // initialHeaderRegionSize
+                    0.2)) { // expansionExtraPercent
 
           Assert.fail("Should have thrown IllegalArgumentException");
         }
@@ -115,7 +116,8 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
                     true, // defensiveCopy
                     1024 * 1024, // preferredExpansionSize
                     4 * 1024, // preferredBlockSize
-                    64 * 1024)) { // initialHeaderRegionSize
+                    64 * 1024, // initialHeaderRegionSize
+                    0.2)) { // expansionExtraPercent
 
           Assert.fail("Should have thrown IOException for file size validation");
         }
@@ -140,7 +142,7 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
 
             // Corrupt it to cause validation failure
             try (RandomAccessFile raf = new RandomAccessFile(testFile.toFile(), "rw")) {
-              raf.seek(5); // numRecords position
+              raf.seek(16); // NUM_RECORDS_HEADER_LOCATION = Long.BYTES + Long.BYTES (8 + 8)
               raf.writeInt(999); // Invalid record count
             }
 
@@ -159,7 +161,8 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
                           true,
                           1024 * 1024,
                           4 * 1024,
-                          64 * 1024)) {
+                          64 * 1024,
+                          0.2)) {
                 // Constructor should fail
               }
             } catch (IOException expected) {
@@ -212,7 +215,8 @@ public class FileRecordStoreConstructorResourceLeakDemoTest extends JulLoggingCo
               true, // defensiveCopy
               1024 * 1024, // preferredExpansionSize
               4 * 1024, // preferredBlockSize
-              64 * 1024)) { // initialHeaderRegionSize
+              64 * 1024, // initialHeaderRegionSize
+              0.2)) { // expansionExtraPercent
 
         logger.log(Level.FINE, "✓ Store opened successfully - constructor flow completed");
 

--- a/src/test/java/com/github/simbo1905/nfp/srs/FileRecordStoreConstructorResourceLeakTest.java
+++ b/src/test/java/com/github/simbo1905/nfp/srs/FileRecordStoreConstructorResourceLeakTest.java
@@ -37,6 +37,7 @@ public class FileRecordStoreConstructorResourceLeakTest extends JulLoggingConfig
               new FileRecordStoreBuilder()
                   .path(tempFile)
                   .maxKeyLength(64) // Expect 64, but file has 32
+                  .accessMode(FileRecordStoreBuilder.AccessMode.READ_ONLY)
                   .open()) {
         Assert.fail("Should have thrown IllegalArgumentException");
       } catch (IllegalArgumentException e) {
@@ -85,7 +86,11 @@ public class FileRecordStoreConstructorResourceLeakTest extends JulLoggingConfig
       // This should fail with IOException due to file size validation
       try (@SuppressWarnings("unused")
           FileRecordStore store =
-              new FileRecordStoreBuilder().path(tempFile).maxKeyLength(64).open()) {
+              new FileRecordStoreBuilder()
+                  .path(tempFile)
+                  .maxKeyLength(64)
+                  .accessMode(FileRecordStoreBuilder.AccessMode.READ_ONLY)
+                  .open()) {
         Assert.fail("Should have thrown IOException");
       } catch (IOException e) {
         logger.log(Level.FINE, "✓ Got expected file size exception: " + e.getMessage());

--- a/src/test/java/com/github/simbo1905/nfp/srs/HeaderExpansionITCase.java
+++ b/src/test/java/com/github/simbo1905/nfp/srs/HeaderExpansionITCase.java
@@ -1,0 +1,137 @@
+package com.github.simbo1905.nfp.srs;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import net.jqwik.api.*;
+
+/// Property-based integration test for header expansion and file growth strategies.
+/// Tests various combinations of key sizes, block sizes, and expansion ratios
+/// to verify correct behavior under stress conditions.
+public class HeaderExpansionITCase {
+
+  /// Property-based test for header expansion behavior with random parameters.
+  /// Runs until 3 header expansions AND 3 file expansions occur, OR total payload reaches 4 KiB.
+  @Property(tries = 50)
+  void testHeaderExpansionWithRandomParameters(
+      @ForAll("keyLengths") int maxKeyLength,
+      @ForAll("blockSizes") int preferredBlockSize,
+      @ForAll("expansionPercents") double expansionExtraPercent,
+      @ForAll("recordCounts") int targetRecordCount)
+      throws IOException {
+
+    // Create temporary directory for test
+    Path tempDir = Files.createTempDirectory("header-expansion-test");
+    File dbFile = tempDir.resolve("test.db").toFile();
+
+    try {
+      // Build store with test parameters
+      FileRecordStoreBuilder builder =
+          new FileRecordStoreBuilder()
+              .path(dbFile.toPath())
+              .maxKeyLength(maxKeyLength)
+              .hintPreferredBlockSize(preferredBlockSize) // preferredBlockSize is in KiB
+              .withExpansionExtraPercent(expansionExtraPercent)
+              .preallocatedRecords(0)
+              .allowZeroPreallocation();
+
+      try (FileRecordStore store = builder.open()) {
+        Random random = new Random(42); // Fixed seed for reproducibility
+        int headerExpansions = 0;
+        int fileExpansions = 0;
+        long totalPayloadSize = 0;
+        long previousDataStartPtr = store.dataStartPtr;
+        long previousFileLength = store.getFileLength();
+
+        List<byte[]> keys = new ArrayList<>();
+
+        // Insert records until we hit one of the termination conditions
+        while ((headerExpansions < 3 || fileExpansions < 3) && totalPayloadSize < 4096) {
+          // Generate random key (length between 1 and maxKeyLength)
+          int keyLen = 1 + random.nextInt(maxKeyLength);
+          byte[] key = new byte[keyLen];
+          random.nextBytes(key);
+
+          // Generate random payload (length between 1 and 512 bytes)
+          int payloadLen = 1 + random.nextInt(512);
+          byte[] payload = new byte[payloadLen];
+          random.nextBytes(payload);
+
+          try {
+            store.insertRecord(key, payload);
+            keys.add(key);
+            totalPayloadSize += payloadLen;
+
+            // Detect header expansion (dataStartPtr increased)
+            if (store.dataStartPtr > previousDataStartPtr) {
+              headerExpansions++;
+              previousDataStartPtr = store.dataStartPtr;
+            }
+
+            // Detect file expansion (file length increased)
+            long currentFileLength = store.getFileLength();
+            if (currentFileLength > previousFileLength) {
+              fileExpansions++;
+              previousFileLength = currentFileLength;
+            }
+
+            // Stop if we've inserted enough records
+            if (keys.size() >= targetRecordCount) {
+              break;
+            }
+          } catch (Exception e) {
+            // Record insertion failed - this may be expected depending on configuration
+            // For now, just break the loop
+            break;
+          }
+        }
+
+        // TODO: Add validation logic here
+        // For now, just verify store is still operational
+        if (!keys.isEmpty()) {
+          byte[] firstKey = keys.get(0);
+          if (store.recordExists(firstKey)) {
+            byte[] readData = store.readRecordData(firstKey);
+            // Basic sanity check - data was retrieved
+            assert readData != null : "Read data should not be null";
+          }
+        }
+      }
+    } finally {
+      // Cleanup
+      if (dbFile.exists()) {
+        dbFile.delete();
+      }
+      Files.deleteIfExists(tempDir);
+    }
+  }
+
+  /// Arbitrary provider for max key lengths: 8, 16, 32, 64, 128 bytes.
+  @Provide
+  Arbitrary<Integer> keyLengths() {
+    return Arbitraries.of(8, 16, 32, 64, 128);
+  }
+
+  /// Arbitrary provider for preferred block sizes (in KiB): 1, 2, 4, 8, 16.
+  /// These are small sizes to stress-test the expansion logic.
+  @Provide
+  Arbitrary<Integer> blockSizes() {
+    return Arbitraries.of(1, 2, 4, 8, 16);
+  }
+
+  /// Arbitrary provider for expansion percentages: 0.1, 0.2, 0.5 (10%, 20%, 50%).
+  @Provide
+  Arbitrary<Double> expansionPercents() {
+    return Arbitraries.of(0.1, 0.2, 0.5);
+  }
+
+  /// Arbitrary provider for target record counts: 0, 1, 3, 5, 10, 20.
+  @Provide
+  Arbitrary<Integer> recordCounts() {
+    return Arbitraries.of(0, 1, 3, 5, 10, 20);
+  }
+}

--- a/src/test/java/com/github/simbo1905/nfp/srs/RecordsFileSimulatesDiskFailures.java
+++ b/src/test/java/com/github/simbo1905/nfp/srs/RecordsFileSimulatesDiskFailures.java
@@ -21,7 +21,8 @@ public class RecordsFileSimulatesDiskFailures extends FileRecordStore {
         true,
         1024 * 1024,
         4 * 1024,
-        64 * 1024);
+        64 * 1024,
+        0.2);
     this.fileOperations =
         new InterceptedRandomAccessFile(new RandomAccessFile(new File(dbPath), "rw"), wc);
   }

--- a/src/test/java/com/github/simbo1905/nfp/srs/api/SimpleRecordStoreApiTest.java
+++ b/src/test/java/com/github/simbo1905/nfp/srs/api/SimpleRecordStoreApiTest.java
@@ -874,7 +874,8 @@ public class SimpleRecordStoreApiTest extends JulLoggingConfig {
             true,
             tinyExpansionBytes,
             tinyBlockSize,
-            tinyHeaderBytes);
+            tinyHeaderBytes,
+            0.2);
 
     // Use a pattern that won't produce CRC ending in zeros - alternating bytes
     StringBuilder keyBuilder = new StringBuilder();
@@ -904,7 +905,8 @@ public class SimpleRecordStoreApiTest extends JulLoggingConfig {
             true,
             tinyExpansionBytes,
             tinyBlockSize,
-            tinyHeaderBytes);
+            tinyHeaderBytes,
+            0.2);
 
     String put0 = new String(recordsFile.readRecordData(longestKey.getBytes()));
 
@@ -932,7 +934,8 @@ public class SimpleRecordStoreApiTest extends JulLoggingConfig {
             true,
             tinyExpansionBytes,
             tinyBlockSize,
-            tinyHeaderBytes);
+            tinyHeaderBytes,
+            0.2);
 
     byte[] shortKey = "hello".getBytes(StandardCharsets.US_ASCII);
     byte[] value = "world".getBytes(StandardCharsets.US_ASCII);
@@ -951,7 +954,8 @@ public class SimpleRecordStoreApiTest extends JulLoggingConfig {
             true,
             tinyExpansionBytes,
             tinyBlockSize,
-            tinyHeaderBytes);
+            tinyHeaderBytes,
+            0.2);
 
     byte[] got = recordsFile.readRecordData(shortKey);
     Assert.assertArrayEquals(value, got);


### PR DESCRIPTION
We are explicitly checking that the two maps are in sync; yet we update with locks, and if we throw, we halt processing. This means we should assert only during unit tests. 